### PR TITLE
Add README HTML validation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,25 +5,26 @@ Olá! Me chamo Vitor Cabrera, sou um intusiasta no ramo da tecnologia e desenvol
 
 
 ## Estou me desenvolvendo nas seguintes áreasa:
-<p align="left">  </a> </a> 
+<p align="left"></p>
 
 ![PYTHON](https://skillicons.dev/icons?i=python)
 ![C](https://skillicons.dev/icons?i=c)
 ##
 
-<div> 
+<div>
     <a href="https://github.com/Vitor-Cabrera">
     <img height="196" src="https://github-readme-stats.vercel.app/api?username=Vitor-Cabrera&coun_private=true&show_icons=true&title_color=512E5F&icon_color=512E5F&border_color=512E5F&border_radius=9" />
 <!---
     Darkmode = https://github-readme-stats.vercel.app/api?username=Vitor-Cabrera&coun_private=true&show_icons=true&theme=dark&border_radius=10
 -->
-    <img height="196" src="https://github-readme-stats.vercel.app/api/top-langs/?username=Vitor-Cabrera&layout=compact&langs_count=10&title_color=512E5F&icon_color=512E5F&border_color=512E5F&border_radius=9">
-
+    <img height="196" src="https://github-readme-stats.vercel.app/api/top-langs/?username=Vitor-Cabrera&layout=compact&langs_count=10&title_color=512E5F&icon_color=512E5F&border_color=512E5F&border_radius=9" />
+    </a>
 </div>
- 
 
+## Rodando os testes
 
+Os testes ficam na pasta `tests/`. Para executá-los, instale o `pytest` (e opcionalmente `beautifulsoup4`) e rode:
 
-
-
-
+```bash
+pytest
+```

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,0 +1,44 @@
+import os
+from html.parser import HTMLParser
+
+SELF_CLOSING = {
+    'area', 'base', 'br', 'col', 'embed', 'hr', 'img',
+    'input', 'link', 'meta', 'param', 'source', 'track', 'wbr'
+}
+
+class TagChecker(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.stack = []
+        self.unmatched = False
+
+    def handle_starttag(self, tag, attrs):
+        if tag not in SELF_CLOSING:
+            self.stack.append(tag)
+
+    def handle_startendtag(self, tag, attrs):
+        # self closing tags handled implicitly
+        pass
+
+    def handle_endtag(self, tag):
+        if self.stack and self.stack[-1] == tag:
+            self.stack.pop()
+        else:
+            self.unmatched = True
+
+    def error(self, message):
+        self.unmatched = True
+
+
+def all_tags_closed(html: str) -> bool:
+    parser = TagChecker()
+    parser.feed(html)
+    parser.close()
+    return not parser.unmatched and len(parser.stack) == 0
+
+
+def test_readme_html_tags_closed():
+    root_dir = os.path.dirname(os.path.dirname(__file__))
+    with open(os.path.join(root_dir, 'README.md'), encoding='utf-8') as f:
+        content = f.read()
+    assert all_tags_closed(content), 'Existem tags HTML não fechadas corretamente em README.md'


### PR DESCRIPTION
## Summary
- add `tests/test_readme.py` to verify that `README.md` has all HTML tags properly closed
- fix HTML tags in `README.md` and document how to run the tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c29c36b888321b127f64980dcbe01